### PR TITLE
Add backup monitoring for Home Assistant

### DIFF
--- a/7.0/Home Assistant - Zabbix.yaml
+++ b/7.0/Home Assistant - Zabbix.yaml
@@ -113,6 +113,115 @@ zabbix_export:
               expression: 'last(/Home Assistant - Zabbix/update.home.assistant.supervisor.update)=1'
               name: 'Home Assistant update for Home Assistant supervisor Update is available.'
               priority: AVERAGE
+        - uuid: ff897cd88d7246c998ce13682b7792f5
+          name: 'Home Assistant Backup Next Scheduled Automatic Backup'
+          type: DEPENDENT
+          key: backup.next.scheduled.automatic
+          delay: '0'
+          trends: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body[?(@.entity_id==''sensor.backup_next_scheduled_automatic_backup'')].state.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  if (value === '0' || value === '' || value === 'unknown' || value === 'unavailable' || value === 'none' || value === 'null') {
+                      return 0;
+                  }
+                  
+                  var timestamp = Date.parse(value);
+                  if (isNaN(timestamp)) {
+                      return 0;
+                  }
+                  
+                  return Math.floor(timestamp / 1000);
+          master_item:
+            key: ha.raw
+          tags:
+            - tag: 'Home Assistant'
+              value: backup
+          triggers:
+            - uuid: 49b9c354c6904c8eb4793393232bf2a1
+              expression: 'last(/Home Assistant - Zabbix/backup.next.scheduled.automatic)=0 and {$SWITCH.TRIGGER.BACKUP}=1'
+              name: 'Home Assistant automatic backup next schedule is missing'
+              priority: WARNING
+              manual_close: 'YES'
+        - uuid: 0eb9b97e0709415a9c439c5375f9d524
+          name: 'Home Assistant Backup Last Successful Automatic Backup'
+          type: DEPENDENT
+          key: backup.last.successful.automatic
+          delay: '0'
+          trends: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body[?(@.entity_id==''sensor.backup_last_successful_automatic_backup'')].state.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  if (value === '0' || value === '' || value === 'unknown' || value === 'unavailable' || value === 'none' || value === 'null') {
+                      return 0;
+                  }
+                  
+                  var timestamp = Date.parse(value);
+                  if (isNaN(timestamp)) {
+                      return 0;
+                  }
+                  
+                  return Math.floor(timestamp / 1000);
+          master_item:
+            key: ha.raw
+          tags:
+            - tag: 'Home Assistant'
+              value: backup
+          triggers:
+            - uuid: ce5b1a1618354859a2c6a4be02cfc9c7
+              expression: 'last(/Home Assistant - Zabbix/backup.last.successful.automatic)>0 and now()-last(/Home Assistant - Zabbix/backup.last.successful.automatic)>{$BACKUP.LAST.SUCCESS.MAX.HOURS}*3600 and {$SWITCH.TRIGGER.BACKUP}=1'
+              name: 'No successful Home Assistant automatic backup in {$BACKUP.LAST.SUCCESS.MAX.HOURS} hours'
+              priority: HIGH
+        - uuid: 05381bfc687a4e0896beb8261f27ab78
+          name: 'Home Assistant Backup Last Attempted Automatic Backup'
+          type: DEPENDENT
+          key: backup.last.attempted.automatic
+          delay: '0'
+          trends: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body[?(@.entity_id==''sensor.backup_last_attempted_automatic_backup'')].state.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  if (value === '0' || value === '' || value === 'unknown' || value === 'unavailable' || value === 'none' || value === 'null') {
+                      return 0;
+                  }
+                  
+                  var timestamp = Date.parse(value);
+                  if (isNaN(timestamp)) {
+                      return 0;
+                  }
+                  
+                  return Math.floor(timestamp / 1000);
+          master_item:
+            key: ha.raw
+          tags:
+            - tag: 'Home Assistant'
+              value: backup
+          triggers:
+            - uuid: 09c1a17ec3f74378bf577c8abb8a32f5
+              expression: 'last(/Home Assistant - Zabbix/backup.last.attempted.automatic)>0 and last(/Home Assistant - Zabbix/backup.last.successful.automatic)>0 and last(/Home Assistant - Zabbix/backup.last.attempted.automatic)-last(/Home Assistant - Zabbix/backup.last.successful.automatic)>{$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS}*3600 and {$SWITCH.TRIGGER.BACKUP}=1'
+              name: 'Home Assistant automatic backup attempt is newer than the last successful backup by more than {$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS} hours'
+              priority: WARNING
       discovery_rules:
         - uuid: 4a40f645dc4d49218ff7460cb4704a96
           name: HA-backup.manager.state
@@ -175,7 +284,7 @@ zabbix_export:
                 key: ha.raw
               tags:
                 - tag: 'Home Assistant'
-                  value: backup-manager-state
+                  value: backup
           master_item:
             key: ha.raw
           lld_macro_paths:
@@ -4559,6 +4668,12 @@ zabbix_export:
         - macro: '{$AQI.MAX}'
           value: '100'
           description: 'AQI warning threshold.'
+        - macro: '{$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS}'
+          value: '2'
+          description: 'Maximum allowed age difference in hours between the last attempted and last successful automatic backup.'
+        - macro: '{$BACKUP.LAST.SUCCESS.MAX.HOURS}'
+          value: '48'
+          description: 'Maximum age in hours of the last successful automatic backup.'
         - macro: '{$BATTERY.MINIMUM}'
           value: '30'
           description: 'The trigger activates when the battery drops below 30%.'
@@ -4602,6 +4717,9 @@ zabbix_export:
         - macro: '{$SWITCH.TRIGGER.AQI}'
           value: '1'
           description: '1 = enable 0 = disable AQI triggers'
+        - macro: '{$SWITCH.TRIGGER.BACKUP}'
+          value: '0'
+          description: '1 = enable 0 = disable automatic backup triggers (off by default)'
         - macro: '{$SWITCH.TRIGGER.BATTERY}'
           value: '1'
           description: '1 = enable 0 = disable'

--- a/7.0/Home Assistant - Zabbix.yaml
+++ b/7.0/Home Assistant - Zabbix.yaml
@@ -340,14 +340,58 @@ zabbix_export:
           type: DEPENDENT
           key: backup.automatic.stage
           delay: '0'
-          history: 30d
-          value_type: TEXT
           trends: '0'
+          valuemap:
+            name: backup_automatic_stage
           preprocessing:
             - type: JSONPATH
               parameters:
                 - '$.body[?(@.entity_id==''event.backup_automatic_backup'')].attributes.backup_stage.first()'
               error_handler: CUSTOM_VALUE
+              error_handler_params: '10'
+            - type: STR_REPLACE
+              parameters:
+                - addon_repositories
+                - '1'
+            - type: STR_REPLACE
+              parameters:
+                - addons
+                - '2'
+            - type: STR_REPLACE
+              parameters:
+                - await_addon_restarts
+                - '3'
+            - type: STR_REPLACE
+              parameters:
+                - docker_config
+                - '4'
+            - type: STR_REPLACE
+              parameters:
+                - cleaning_up
+                - '5'
+            - type: STR_REPLACE
+              parameters:
+                - finishing_file
+                - '6'
+            - type: STR_REPLACE
+              parameters:
+                - folders
+                - '7'
+            - type: STR_REPLACE
+              parameters:
+                - home_assistant
+                - '8'
+            - type: STR_REPLACE
+              parameters:
+                - upload_to_agents
+                - '9'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  if (value === '' || value === 'null' || value === 'None' || value === 'none') {
+                      return '0';
+                  }
+                  return value;
           master_item:
             key: ha.raw
           tags:
@@ -5366,6 +5410,31 @@ zabbix_export:
             - value: '2'
               newvalue: failed
             - value: '3'
+              newvalue: unavailable
+        - uuid: 5e380b834c0e456b96a2140162ae92b7
+          name: backup_automatic_stage
+          mappings:
+            - value: '0'
+              newvalue: none
+            - value: '1'
+              newvalue: addon_repositories
+            - value: '2'
+              newvalue: addons
+            - value: '3'
+              newvalue: await_addon_restarts
+            - value: '4'
+              newvalue: docker_config
+            - value: '5'
+              newvalue: cleaning_up
+            - value: '6'
+              newvalue: finishing_file
+            - value: '7'
+              newvalue: folders
+            - value: '8'
+              newvalue: home_assistant
+            - value: '9'
+              newvalue: upload_to_agents
+            - value: '10'
               newvalue: unavailable
         - uuid: 6aea8103a50d4c5c8b2800a006c8e250
           name: battery

--- a/7.0/Home Assistant - Zabbix.yaml
+++ b/7.0/Home Assistant - Zabbix.yaml
@@ -113,6 +113,53 @@ zabbix_export:
               expression: 'last(/Home Assistant - Zabbix/update.home.assistant.supervisor.update)=1'
               name: 'Home Assistant update for Home Assistant supervisor Update is available.'
               priority: AVERAGE
+        - uuid: 81e5212a0b914238b2fe98a247f1f838
+          name: 'Home Assistant Backup Manager State'
+          type: DEPENDENT
+          key: backup.manager.state
+          delay: '0'
+          trends: '0'
+          description: |
+            | Number | State Key        | Description     |
+            | ---: | :--------------- | :--------------- |
+            |    0 | `idle`           | Idle             |
+            |    1 | `create_backup`  | Creating backup  |
+            |    2 | `receive_backup` | Receiving backup |
+            |    3 | `restore_backup` | Restoring backup |
+            |    4 | `blocked`        | Backup blocked   |
+          valuemap:
+            name: backup_manager
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body[?(@.entity_id==''sensor.backup_backup_manager_state'')].state.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '-1'
+            - type: STR_REPLACE
+              parameters:
+                - idle
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - create_backup
+                - '1'
+            - type: STR_REPLACE
+              parameters:
+                - receive_backup
+                - '2'
+            - type: STR_REPLACE
+              parameters:
+                - restore_backup
+                - '3'
+            - type: STR_REPLACE
+              parameters:
+                - blocked
+                - '4'
+          master_item:
+            key: ha.raw
+          tags:
+            - tag: 'Home Assistant'
+              value: backup
         - uuid: ff897cd88d7246c998ce13682b7792f5
           name: 'Home Assistant Backup Next Scheduled Automatic Backup'
           type: DEPENDENT
@@ -217,89 +264,82 @@ zabbix_export:
           tags:
             - tag: 'Home Assistant'
               value: backup
-          triggers:
-            - uuid: 09c1a17ec3f74378bf577c8abb8a32f5
-              expression: 'last(/Home Assistant - Zabbix/backup.last.attempted.automatic)>0 and last(/Home Assistant - Zabbix/backup.last.successful.automatic)>0 and last(/Home Assistant - Zabbix/backup.last.attempted.automatic)-last(/Home Assistant - Zabbix/backup.last.successful.automatic)>{$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS}*3600 and {$SWITCH.TRIGGER.BACKUP}=1'
-              name: 'Home Assistant automatic backup attempt is newer than the last successful backup by more than {$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS} hours'
-              priority: WARNING
-      discovery_rules:
-        - uuid: 4a40f645dc4d49218ff7460cb4704a96
-          name: HA-backup.manager.state
+        - uuid: a2994acba7904faa9642db9883964e99
+          name: 'Home Assistant Automatic Backup Event Type'
           type: DEPENDENT
-          key: backup.manager.state
+          key: backup.automatic.event.type
           delay: '0'
-          filter:
-            conditions:
-              - macro: '{#ENTITY_ID}'
-                value: ^sensor\.backup_backup_manager_.+$
-                formulaid: A
-          item_prototypes:
-            - uuid: 1ea35f8966a8415bb8838017e28c1439
-              name: '{#FRIENDLY_NAME}'
-              type: DEPENDENT
-              key: 'backup.manager.state[{#ENTITY_ID}]'
-              delay: '0'
-              trends: '0'
-              description: |
-                | Number | State Key        | Description     |
-                | ---: | :--------------- | :--------------- |
-                |    0 | `idle`           | Idle             |
-                |    1 | `create_backup`  | Creating backup  |
-                |    2 | `receive_backup` | Receiving backup |
-                |    3 | `restore_backup` | Restoring backup |
-                |    4 | `blocked`        | Backup blocked   |
-              valuemap:
-                name: backup_manager
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body[?(@.entity_id == "{#ENTITY_ID}")].state'
-                - type: LTRIM
-                  parameters:
-                    - '["'
-                - type: RTRIM
-                  parameters:
-                    - '"]'
-                - type: STR_REPLACE
-                  parameters:
-                    - idle
-                    - '0'
-                - type: STR_REPLACE
-                  parameters:
-                    - create_backup
-                    - '1'
-                - type: STR_REPLACE
-                  parameters:
-                    - receive_backup
-                    - '2'
-                - type: STR_REPLACE
-                  parameters:
-                    - restore_backup
-                    - '3'
-                - type: STR_REPLACE
-                  parameters:
-                    - blocked
-                    - '4'
-              master_item:
-                key: ha.raw
-              tags:
-                - tag: 'Home Assistant'
-                  value: backup
-          master_item:
-            key: ha.raw
-          lld_macro_paths:
-            - lld_macro: '{#ENTITY_ID}'
-              path: $.entity_id
-            - lld_macro: '{#FRIENDLY_NAME}'
-              path: $.attributes.friendly_name
-            - lld_macro: '{#UNITS}'
-              path: $.attributes.unit_of_measurement
+          trends: '0'
+          valuemap:
+            name: backup_automatic_event
           preprocessing:
             - type: JSONPATH
               parameters:
-                - '$.body[*]'
+                - '$.body[?(@.entity_id==''event.backup_automatic_backup'')].attributes.event_type.first()'
               error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
+              error_handler_params: '-1'
+            - type: STR_REPLACE
+              parameters:
+                - completed
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - in_progress
+                - '1'
+            - type: STR_REPLACE
+              parameters:
+                - failed
+                - '2'
+          master_item:
+            key: ha.raw
+          tags:
+            - tag: 'Home Assistant'
+              value: backup
+          triggers:
+            - uuid: 0a06ebc542ac4d679fe65ae66d4a256e
+              expression: 'last(/Home Assistant - Zabbix/backup.automatic.event.type)=2 and {$SWITCH.TRIGGER.BACKUP}=1'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/Home Assistant - Zabbix/backup.automatic.event.type)=0 and {$SWITCH.TRIGGER.BACKUP}=1'
+              name: 'Home Assistant automatic backup failed'
+              priority: HIGH
+              manual_close: 'YES'
+        - uuid: ee7a12e0b6604302825f605b317b6a37
+          name: 'Home Assistant Automatic Backup Failed Reason'
+          type: DEPENDENT
+          key: backup.automatic.failed.reason
+          delay: '0'
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body[?(@.entity_id==''event.backup_automatic_backup'')].attributes.failed_reason.first()'
+              error_handler: CUSTOM_VALUE
+          master_item:
+            key: ha.raw
+          tags:
+            - tag: 'Home Assistant'
+              value: backup
+        - uuid: 0b73cabcd97e403ca7cfd175476120f2
+          name: 'Home Assistant Automatic Backup Stage'
+          type: DEPENDENT
+          key: backup.automatic.stage
+          delay: '0'
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body[?(@.entity_id==''event.backup_automatic_backup'')].attributes.backup_stage.first()'
+              error_handler: CUSTOM_VALUE
+          master_item:
+            key: ha.raw
+          tags:
+            - tag: 'Home Assistant'
+              value: backup
+      discovery_rules:
         - uuid: 9191d005e6204149a071250e7f756bcd
           name: HA-addon-running
           type: DEPENDENT
@@ -4668,9 +4708,6 @@ zabbix_export:
         - macro: '{$AQI.MAX}'
           value: '100'
           description: 'AQI warning threshold.'
-        - macro: '{$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS}'
-          value: '2'
-          description: 'Maximum allowed age difference in hours between the last attempted and last successful automatic backup.'
         - macro: '{$BACKUP.LAST.SUCCESS.MAX.HOURS}'
           value: '48'
           description: 'Maximum age in hours of the last successful automatic backup.'
@@ -5303,6 +5340,17 @@ zabbix_export:
               newvalue: 'Restoring a backup'
             - value: '4'
               newvalue: Blocked
+        - uuid: 9fc3f5559fd444628d3c5564f5c3ef6b
+          name: backup_automatic_event
+          mappings:
+            - value: '0'
+              newvalue: completed
+            - value: '1'
+              newvalue: 'in progress'
+            - value: '2'
+              newvalue: failed
+            - value: '-1'
+              newvalue: unavailable
         - uuid: 6aea8103a50d4c5c8b2800a006c8e250
           name: battery
           mappings:

--- a/7.0/Home Assistant - Zabbix.yaml
+++ b/7.0/Home Assistant - Zabbix.yaml
@@ -127,6 +127,7 @@ zabbix_export:
             |    2 | `receive_backup` | Receiving backup |
             |    3 | `restore_backup` | Restoring backup |
             |    4 | `blocked`        | Backup blocked   |
+            |    5 | `unavailable`    | Unavailable      |
           valuemap:
             name: backup_manager
           preprocessing:
@@ -134,7 +135,7 @@ zabbix_export:
               parameters:
                 - '$.body[?(@.entity_id==''sensor.backup_backup_manager_state'')].state.first()'
               error_handler: CUSTOM_VALUE
-              error_handler_params: '-1'
+              error_handler_params: '5'
             - type: STR_REPLACE
               parameters:
                 - idle
@@ -155,6 +156,10 @@ zabbix_export:
               parameters:
                 - blocked
                 - '4'
+            - type: STR_REPLACE
+              parameters:
+                - unavailable
+                - '5'
           master_item:
             key: ha.raw
           tags:
@@ -277,7 +282,7 @@ zabbix_export:
               parameters:
                 - '$.body[?(@.entity_id==''event.backup_automatic_backup'')].attributes.event_type.first()'
               error_handler: CUSTOM_VALUE
-              error_handler_params: '-1'
+              error_handler_params: '3'
             - type: STR_REPLACE
               parameters:
                 - completed
@@ -290,6 +295,10 @@ zabbix_export:
               parameters:
                 - failed
                 - '2'
+            - type: STR_REPLACE
+              parameters:
+                - unavailable
+                - '3'
           master_item:
             key: ha.raw
           tags:
@@ -5340,6 +5349,8 @@ zabbix_export:
               newvalue: 'Restoring a backup'
             - value: '4'
               newvalue: Blocked
+            - value: '5'
+              newvalue: unavailable
         - uuid: 9fc3f5559fd444628d3c5564f5c3ef6b
           name: backup_automatic_event
           mappings:
@@ -5349,7 +5360,7 @@ zabbix_export:
               newvalue: 'in progress'
             - value: '2'
               newvalue: failed
-            - value: '-1'
+            - value: '3'
               newvalue: unavailable
         - uuid: 6aea8103a50d4c5c8b2800a006c8e250
           name: battery

--- a/7.0/Home Assistant - Zabbix.yaml
+++ b/7.0/Home Assistant - Zabbix.yaml
@@ -197,8 +197,8 @@ zabbix_export:
             - tag: 'Home Assistant'
               value: backup
           triggers:
-            - uuid: 49b9c354c6904c8eb4793393232bf2a1
-              expression: 'last(/Home Assistant - Zabbix/backup.next.scheduled.automatic)=0 and {$SWITCH.TRIGGER.BACKUP}=1'
+            - uuid: 8af3baa6872b4914bf4d824f5e649455
+              expression: 'last(/Home Assistant - Zabbix/backup.next.scheduled.automatic)=0 and last(/Home Assistant - Zabbix/backup.manager.state)<>5 and last(/Home Assistant - Zabbix/backup.automatic.event.type)<>3 and {$SWITCH.TRIGGER.BACKUP}=1'
               name: 'Home Assistant automatic backup next schedule is missing'
               priority: WARNING
               manual_close: 'YES'
@@ -311,6 +311,11 @@ zabbix_export:
               recovery_expression: 'last(/Home Assistant - Zabbix/backup.automatic.event.type)=0 and {$SWITCH.TRIGGER.BACKUP}=1'
               name: 'Home Assistant automatic backup failed'
               priority: HIGH
+              manual_close: 'YES'
+            - uuid: 8cf7e5aafbf34d55aacbe2d49b64fca1
+              expression: '(last(/Home Assistant - Zabbix/backup.manager.state)=5 or last(/Home Assistant - Zabbix/backup.automatic.event.type)=3) and {$SWITCH.TRIGGER.BACKUP}=1'
+              name: 'Home Assistant backup integration is unavailable'
+              priority: WARNING
               manual_close: 'YES'
         - uuid: ee7a12e0b6604302825f605b317b6a37
           name: 'Home Assistant Automatic Backup Failed Reason'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ ha.raw  (HTTP_AGENT → /api/states, Bearer {$API.TOKEN})
 | HA Core Update | Whether a Home Assistant Core update is available (1=yes, 0=no, 2=unavailable) |
 | HA Supervisor Update | Whether a Supervisor update is available |
 | Backup Manager State | State of the HA backup manager (idle / creating / receiving / restoring / blocked) |
+| Backup Next Scheduled Automatic Backup | Next scheduled automatic backup time, stored as Unix time |
+| Backup Last Successful Automatic Backup | Last successful automatic backup time, stored as Unix time |
+| Backup Last Attempted Automatic Backup | Last attempted automatic backup time, stored as Unix time |
 | Integration Updates | Update availability for all installed integrations |
 | Firmware Updates | Firmware update availability for connected devices (device_class: firmware) |
 | Restart Required | Services or integrations requiring a restart |
@@ -200,6 +203,8 @@ ha.raw  (HTTP_AGENT → /api/states, Bearer {$API.TOKEN})
 | `{$AQI.MAX}` | `100` | Air quality index warning threshold |
 | `{$SOUND.PRESSURE.MAX.DB}` | `80` | Sound pressure warning threshold (dB) |
 | `{$SAFETY.SENSOR.NODATA.TIMEOUT}` | `1800` | Seconds without data before safety sensor offline trigger fires |
+| `{$BACKUP.LAST.SUCCESS.MAX.HOURS}` | `48` | Maximum age in hours of the last successful automatic backup |
+| `{$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS}` | `2` | Maximum allowed difference in hours between the last attempted and last successful automatic backup |
 
 ### Temperature Thresholds
 
@@ -245,6 +250,7 @@ All trigger switches accept context macros — e.g. `{$SWITCH.TRIGGER.BATTERY:"{
 | `{$SWITCH.TRIGGER.LOCK}` | `1` | Lock jammed trigger (1 or 0) |
 | `{$SWITCH.TRIGGER.LOCK.OPEN}` | `0` | Lock unlocked trigger (1 or 0, off by default) |
 | `{$SWITCH.TRIGGER.ADDON.RUNNING}` | `1` | Add-on not running trigger (1 or 0) |
+| `{$SWITCH.TRIGGER.BACKUP}` | `0` | Backup triggers: missing next schedule, stale successful backup, and attempted newer than successful (1 or 0, off by default) |
 
 ## Dashboard
 

--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ The template includes a built-in **"Home Assistant - Zabbix"** dashboard with 7 
 | `update` | HA Core, Supervisor, and integration update entities |
 | `firmware-update` | Firmware update entities |
 | `addon-running` | Add-on running state (1=running, 0=stopped, 2=unavailable) |
-| `backup_manager` | Backup manager state (0=idle … 4=blocked) |
-| `backup_automatic_event` | Automatic backup event state (0=completed, 1=in progress, 2=failed, -1=unavailable) |
+| `backup_manager` | Backup manager state (0=idle, 1=create backup, 2=receive backup, 3=restore backup, 4=blocked, 5=unavailable) |
+| `backup_automatic_event` | Automatic backup event state (0=completed, 1=in progress, 2=failed, 3=unavailable) |
 | `battery` | Battery sensors (-1=unavailable) |
 | `temperature` | Temperature sensors (-1=unknown, 0=unavailable) |
 | `automation` | Automation state (0=disabled, 1=enabled, 2=unavailable) |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ha.raw  (HTTP_AGENT → /api/states, Bearer {$API.TOKEN})
 | Backup Last Attempted Automatic Backup | Last attempted automatic backup time, stored as Unix time |
 | Automatic Backup Event Type | State of the last automatic backup task from `event.backup_automatic_backup` (`completed`, `in progress`, `failed`) |
 | Automatic Backup Failed Reason | Failure reason from `event.backup_automatic_backup` when the last automatic backup failed |
-| Automatic Backup Stage | Current `backup_stage` from `event.backup_automatic_backup` while the automatic backup is in progress |
+| Automatic Backup Stage | Current `backup_stage` from `event.backup_automatic_backup`, mapped to a finite set of backup stages |
 | Integration Updates | Update availability for all installed integrations |
 | Firmware Updates | Firmware update availability for connected devices (device_class: firmware) |
 | Restart Required | Services or integrations requiring a restart |
@@ -277,6 +277,7 @@ The template includes a built-in **"Home Assistant - Zabbix"** dashboard with 7 
 | `addon-running` | Add-on running state (1=running, 0=stopped, 2=unavailable) |
 | `backup_manager` | Backup manager state (0=idle, 1=create backup, 2=receive backup, 3=restore backup, 4=blocked, 5=unavailable) |
 | `backup_automatic_event` | Automatic backup event state (0=completed, 1=in progress, 2=failed, 3=unavailable) |
+| `backup_automatic_stage` | Automatic backup stage (0=none, 1=addon_repositories, 2=addons, 3=await_addon_restarts, 4=docker_config, 5=cleaning_up, 6=finishing_file, 7=folders, 8=home_assistant, 9=upload_to_agents, 10=unavailable) |
 | `battery` | Battery sensors (-1=unavailable) |
 | `temperature` | Temperature sensors (-1=unknown, 0=unavailable) |
 | `automation` | Automation state (0=disabled, 1=enabled, 2=unavailable) |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ ha.raw  (HTTP_AGENT → /api/states, Bearer {$API.TOKEN})
 | Backup Next Scheduled Automatic Backup | Next scheduled automatic backup time, stored as Unix time |
 | Backup Last Successful Automatic Backup | Last successful automatic backup time, stored as Unix time |
 | Backup Last Attempted Automatic Backup | Last attempted automatic backup time, stored as Unix time |
+| Automatic Backup Event Type | State of the last automatic backup task from `event.backup_automatic_backup` (`completed`, `in progress`, `failed`) |
+| Automatic Backup Failed Reason | Failure reason from `event.backup_automatic_backup` when the last automatic backup failed |
+| Automatic Backup Stage | Current `backup_stage` from `event.backup_automatic_backup` while the automatic backup is in progress |
 | Integration Updates | Update availability for all installed integrations |
 | Firmware Updates | Firmware update availability for connected devices (device_class: firmware) |
 | Restart Required | Services or integrations requiring a restart |
@@ -204,7 +207,6 @@ ha.raw  (HTTP_AGENT → /api/states, Bearer {$API.TOKEN})
 | `{$SOUND.PRESSURE.MAX.DB}` | `80` | Sound pressure warning threshold (dB) |
 | `{$SAFETY.SENSOR.NODATA.TIMEOUT}` | `1800` | Seconds without data before safety sensor offline trigger fires |
 | `{$BACKUP.LAST.SUCCESS.MAX.HOURS}` | `48` | Maximum age in hours of the last successful automatic backup |
-| `{$BACKUP.ATTEMPT.SUCCESS.DIFF.HOURS}` | `2` | Maximum allowed difference in hours between the last attempted and last successful automatic backup |
 
 ### Temperature Thresholds
 
@@ -250,7 +252,7 @@ All trigger switches accept context macros — e.g. `{$SWITCH.TRIGGER.BATTERY:"{
 | `{$SWITCH.TRIGGER.LOCK}` | `1` | Lock jammed trigger (1 or 0) |
 | `{$SWITCH.TRIGGER.LOCK.OPEN}` | `0` | Lock unlocked trigger (1 or 0, off by default) |
 | `{$SWITCH.TRIGGER.ADDON.RUNNING}` | `1` | Add-on not running trigger (1 or 0) |
-| `{$SWITCH.TRIGGER.BACKUP}` | `0` | Backup triggers: missing next schedule, stale successful backup, and attempted newer than successful (1 or 0, off by default) |
+| `{$SWITCH.TRIGGER.BACKUP}` | `0` | Backup triggers: missing next schedule, stale successful backup, and automatic backup failed event (1 or 0, off by default) |
 
 ## Dashboard
 
@@ -274,6 +276,7 @@ The template includes a built-in **"Home Assistant - Zabbix"** dashboard with 7 
 | `firmware-update` | Firmware update entities |
 | `addon-running` | Add-on running state (1=running, 0=stopped, 2=unavailable) |
 | `backup_manager` | Backup manager state (0=idle … 4=blocked) |
+| `backup_automatic_event` | Automatic backup event state (0=completed, 1=in progress, 2=failed, -1=unavailable) |
 | `battery` | Battery sensors (-1=unavailable) |
 | `temperature` | Temperature sensors (-1=unknown, 0=unavailable) |
 | `automation` | Automation state (0=disabled, 1=enabled, 2=unavailable) |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ All trigger switches accept context macros — e.g. `{$SWITCH.TRIGGER.BATTERY:"{
 | `{$SWITCH.TRIGGER.LOCK}` | `1` | Lock jammed trigger (1 or 0) |
 | `{$SWITCH.TRIGGER.LOCK.OPEN}` | `0` | Lock unlocked trigger (1 or 0, off by default) |
 | `{$SWITCH.TRIGGER.ADDON.RUNNING}` | `1` | Add-on not running trigger (1 or 0) |
-| `{$SWITCH.TRIGGER.BACKUP}` | `0` | Backup triggers: missing next schedule, stale successful backup, and automatic backup failed event (1 or 0, off by default) |
+| `{$SWITCH.TRIGGER.BACKUP}` | `0` | Backup triggers: integration unavailable, missing next schedule, stale successful backup, and automatic backup failed event (1 or 0, off by default) |
 
 ## Dashboard
 


### PR DESCRIPTION
Hi, I like your template and wanted to add backup monitoring as well.

## What changed
This adds monitoring for the Home Assistant Backup integration.

Added items for:
- backup manager state
- next scheduled automatic backup
- last successful automatic backup
- last attempted automatic backup
- automatic backup event type
- automatic backup failed reason
- automatic backup stage

Added backup triggers for:
- missing next scheduled backup
- no successful backup in `{$BACKUP.LAST.SUCCESS.MAX.HOURS}` hours
- automatic backup failed

## Notes
- backup alerts are disabled by default with `{$SWITCH.TRIGGER.BACKUP}=0`
- backup manager state is implemented as a fixed item because the Backup integration exposes a single documented backup manager state entity, so discovery adds complexity without much benefit here
- updated the README and normalized backup item tags to `Home Assistant=backup`